### PR TITLE
fixup: Remove commented-out Python Lambda code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,86 @@
-# Welcome to your CDK TypeScript project
+# AWS CDK BigBlueButton and Scalelite Deployment
 
-This is a blank project for CDK development with TypeScript.
+This project provides an AWS Cloud Development Kit (CDK) solution for deploying a scalable and resilient BigBlueButton (BBB) environment, load-balanced by Scalelite. It leverages various AWS services to create a robust infrastructure suitable for production workloads.
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+## Architecture Overview
+
+The architecture consists of the following key components:
+
+*   **Scalelite:**
+    *   Runs as an Amazon ECS Fargate service, ensuring high availability and removing the need to manage underlying EC2 instances for the load balancer.
+    *   Exposed via an Application Load Balancer (ALB), which is protected by AWS WAFv2 using common AWS Managed Rules.
+    *   Utilizes Amazon EFS (Elastic File System) for persistent storage of BigBlueButton recordings.
+*   **BigBlueButton Cluster:**
+    *   A pool of BigBlueButton servers running on Amazon EC2 instances.
+    *   Managed by an Auto Scaling Group (ASG) to dynamically scale the number of BBB servers based on load.
+    *   Supports the use of EC2 Spot Instances for cost-effective scaling of BBB capacity.
+    *   Instances are automatically registered with Scalelite upon launch.
+    *   Graceful deregistration from Scalelite during scale-in events or instance termination is handled by an ASG lifecycle hook triggering an AWS Lambda function.
+*   **Database:**
+    *   Amazon Aurora MySQL (via RDS) is used for the Scalelite database, providing a scalable and durable relational database.
+*   **Cache:**
+    *   Amazon ElastiCache for Redis is used as a caching layer for Scalelite, improving performance.
+*   **Networking:**
+    *   Deploys into an existing VPC (looked up by name).
+    *   Utilizes public subnets for the Application Load Balancer and BBB EC2 instances (which require public IPs for direct WebRTC media or TURN connectivity).
+    *   Utilizes private subnets for Fargate tasks, database, cache, and EFS mount targets for enhanced security.
+
+## Prerequisites
+
+Before deploying this CDK stack, ensure you have the following prerequisites in place:
+
+*   **Existing VPC:** A Virtual Private Cloud (VPC) must exist in your AWS account in the target region. The CDK application will look up this VPC by the name specified in `cdk.json`.
+*   **Registered Domain Name:** You need a registered domain name (e.g., `your.domain.com`) that you can manage via Route 53 or an external DNS provider (though Route 53 is assumed for DNS record creation for the ALB).
+*   **ACM Certificate:** An SSL/TLS certificate for your domain must be provisioned in AWS Certificate Manager (ACM) in the **same region** where you intend to deploy this stack. The ARN of this certificate is required for configuration.
+*   **EC2 Key Pair (Optional):** An EC2 key pair is recommended for SSH access to the BigBlueButton instances, especially for debugging purposes. The name of this key pair can be configured.
+*   **AWS CLI and CDK Setup:** Ensure your AWS CLI is configured with appropriate credentials and the AWS CDK Toolkit is installed and bootstrapped for your account/region.
+
+## Configuration
+
+Configuration for this CDK deployment is primarily managed through the `cdk.json` file, under the `context` key. You will need to update these values to match your specific environment:
+
+*   `vpcName`: The name of the existing VPC to deploy resources into (e.g., `"my-dev-vpc"`).
+*   `domainName`: Your registered domain name where Scalelite will be accessible (e.g., `"bbb.your.domain.com"`). The A record for the Scalelite ALB will be created under this domain.
+*   `certificateArn`: The full ARN of the ACM certificate for your domain (e.g., `"arn:aws:acm:us-east-1:123456789012:certificate/your-certificate-id"`).
+*   `bbbKeyName` (Optional): The name of your EC2 key pair for SSH access to BBB instances (e.g., `"my-ec2-key"`). If not provided, SSH access might be more complex.
+*   `sshAllowedCidr`: The CIDR block to allow SSH access to the BigBlueButton instances (e.g., `"YOUR_IP_CIDR/32"`). For security, restrict this to your IP address or a specific range. Defaults to `0.0.0.0/0` in the stack if not set, which is not recommended for production.
+
+**Example `cdk.json` context:**
+```json
+{
+  "context": {
+    "vpcName": "my-production-vpc",
+    "domainName": "conferencing.mycompany.com",
+    "certificateArn": "arn:aws:acm:eu-west-1:ACCOUNTID:certificate/CERTIFICATEID",
+    "bbbKeyName": "production-bbb-key",
+    "sshAllowedCidr": "198.51.100.5/32"
+  }
+}
+```
+
+Other configurations, such as instance types for BBB servers or Redis, or desired counts for Fargate tasks, can be modified directly within the respective CDK stack files (e.g., `lib/bbb-cluster-stack.ts`, `lib/database-stack.ts`). These could be further parameterized using context variables if needed.
+
+## Key Features
+
+*   **Scalable BigBlueButton Cluster:** Utilizes EC2 Auto Scaling Groups to automatically adjust the number of BBB servers based on demand.
+*   **Spot Instance Support:** Option to use EC2 Spot Instances for BBB servers to significantly reduce compute costs for scalable capacity.
+*   **Resilient Scalelite Load Balancer:** Scalelite runs as a containerized application on AWS Fargate, managed by ECS for high availability.
+*   **Persistent Recordings:** BigBlueButton recordings are stored on Amazon EFS, providing durable and shared storage accessible by Scalelite.
+*   **WAF Protection:** The Scalelite Application Load Balancer is protected by AWS WAFv2 using AWS Managed Rules for common threats and IP reputation lists.
+*   **Automated Server Management:**
+    *   BBB servers automatically register with Scalelite on launch.
+    *   Graceful deregistration of BBB servers from Scalelite during termination events is handled by ASG lifecycle hooks and an AWS Lambda function.
 
 ## Useful commands
 
 * `npm run build`   compile typescript to js
 * `npm run watch`   watch for changes and compile
 * `npm run test`    perform the jest unit tests
-* `npx cdk deploy`  deploy this stack to your default AWS account/region
+* `npx cdk deploy --all`  deploy all stacks to your default AWS account/region (ensure context in `cdk.json` is set)
+* `npx cdk deploy DatabaseStack`  deploy a specific stack
 * `npx cdk diff`    compare deployed stack with current state
 * `npx cdk synth`   emits the synthesized CloudFormation template
+* `npx cdk context` list context values available to the CDK app
+* `npx cdk destroy` destroy all deployed stacks (use with caution)
+
+Make sure to review the changes with `cdk diff` before deploying.

--- a/bin/bbb-cdk.ts
+++ b/bin/bbb-cdk.ts
@@ -1,6 +1,6 @@
 import 'source-map-support/register';
 import { App, Stack } from 'aws-cdk-lib';
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Vpc, InstanceType, InstanceClass, InstanceSize } from 'aws-cdk-lib/aws-ec2';
 import { DatabaseStack } from '../lib/database-stack';
 import { ScaleliteStack } from '../lib/scalelite-stack';
 import { BbbClusterStack } from '../lib/bbb-cluster-stack';
@@ -10,25 +10,40 @@ const app = new App();
 const account = process.env.CDK_DEFAULT_ACCOUNT!;
 const region  = process.env.CDK_DEFAULT_REGION!;
 
+// Context variables
+const vpcName = app.node.tryGetContext('vpcName') || 'my-dev-vpc';
+const domainName = app.node.tryGetContext('domainName');
+if (!domainName) {
+    throw new Error("Context variable 'domainName' is required. Please set it in cdk.json or via --context.");
+}
+const certificateArn = app.node.tryGetContext('certificateArn');
+if (!certificateArn) {
+    throw new Error("Context variable 'certificateArn' is required. Please set it in cdk.json or via --context.");
+}
+const bbbKeyName = app.node.tryGetContext('bbbKeyName'); // Optional
+const sshAllowedCidr = app.node.tryGetContext('sshAllowedCidr') || '0.0.0.0/0'; // Defaults to open, use context to restrict
+
 const lookup = new Stack(app, 'VpcLookupStack', {
     env: { account, region }
 });
 const vpc = Vpc.fromLookup(lookup, 'DevVPC', {
-    vpcName: 'my-dev-vpc'
+    vpcName: vpcName
 });
 
 const databaseStack = new DatabaseStack(app, 'DatabaseStack', {
     vpc,
+    redisInstanceType: 'cache.t3.small', // This could also be a context variable if needed
     env: { account, region }
 });
 
 const scaleliteStack = new ScaleliteStack(app, 'ScaleliteStack', {
     vpc,
-    dbCluster:      databaseStack.dbCluster,
-    redisEndpoint:  databaseStack.redisEndpoint,
-    sharedSecret:   databaseStack.sharedSecret,
-    domainName:     'example.com',
-    certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/abcdefg',
+    dbCluster:          databaseStack.dbCluster,
+    redisEndpoint:      databaseStack.redisEndpoint,
+    redisSecurityGroup: databaseStack.redisSg,
+    sharedSecret:       databaseStack.sharedSecret,
+    domainName:         domainName,
+    certificateArn:     certificateArn,
     env: { account, region }
 });
 
@@ -36,6 +51,9 @@ new BbbClusterStack(app, 'BbbClusterStack', {
     vpc,
     scaleliteEndpoint: scaleliteStack.apiEndpoint,
     sharedSecret:      databaseStack.sharedSecret,
-    keyName:           'dev-ssh-key',
+    keyName:           bbbKeyName,
+    bbbInstanceType:   InstanceType.of(InstanceClass.M5, InstanceSize.LARGE), // Could be context variable
+    useSpotInstances:  true, // Could be context variable
+    sshAllowedCidr:    sshAllowedCidr,
     env: { account, region }
 });

--- a/cdk.json
+++ b/cdk.json
@@ -91,6 +91,11 @@
     "@aws-cdk/aws-stepfunctions:useDistributedMapResultWriterV2": true,
     "@aws-cdk/s3-notifications:addS3TrustKeyPolicyForSnsSubscriptions": true,
     "@aws-cdk/aws-ec2:requirePrivateSubnetsForEgressOnlyInternetGateway": true,
-    "@aws-cdk/aws-s3:publicAccessBlockedByDefault": true
+    "@aws-cdk/aws-s3:publicAccessBlockedByDefault": true,
+    "vpcName": "my-dev-vpc",
+    "domainName": "your.domain.com",
+    "certificateArn": "arn:aws:acm:REGION:ACCOUNTID:certificate/CERTID",
+    "bbbKeyName": "your-ec2-key-name",
+    "sshAllowedCidr": "YOUR_IP_CIDR/32"
   }
 }

--- a/lib/bbb-cluster-stack.ts
+++ b/lib/bbb-cluster-stack.ts
@@ -1,19 +1,30 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { Stack, StackProps, Duration } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import {
   IVpc, SubnetType, SecurityGroup, Peer, Port,
   InstanceType, InstanceClass, InstanceSize,
   MachineImage, UserData, LaunchTemplate
 } from 'aws-cdk-lib/aws-ec2';
-import { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
+import { SpotMarketType } from 'aws-cdk-lib/aws-autoscaling';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda'; // Keep for Runtime
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as path from 'node:path';
+import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
+import * as hookTargets from 'aws-cdk-lib/aws-autoscaling-hooktargets';
 
 export interface BbbClusterStackProps extends StackProps {
   readonly vpc: IVpc;
   readonly scaleliteEndpoint: string;
   readonly sharedSecret: Secret;
   readonly keyName?: string;
+  readonly bbbInstanceType?: InstanceType;
+  readonly useSpotInstances?: boolean;
+  readonly sshAllowedCidr?: string;
 }
 
 export class BbbClusterStack extends Stack {
@@ -25,7 +36,10 @@ export class BbbClusterStack extends Stack {
       description: 'Allow SSH, HTTP/S, WebRTC',
       allowAllOutbound: true
     });
-    bbbSg.addIngressRule(Peer.anyIpv4(), Port.tcp(22), 'SSH');
+    // SSH access is configurable. Defaults to Peer.anyIpv4() if sshAllowedCidr is not provided.
+    // For production, it is highly recommended to restrict this to a specific IP range.
+    const sshPeer = props.sshAllowedCidr ? Peer.ipv4(props.sshAllowedCidr) : Peer.anyIpv4();
+    bbbSg.addIngressRule(sshPeer, Port.tcp(22), `SSH access ${props.sshAllowedCidr ? `from ${props.sshAllowedCidr}` : '(open to all - consider restricting)'}`);
     bbbSg.addIngressRule(Peer.anyIpv4(), Port.tcp(80), 'HTTP');
     bbbSg.addIngressRule(Peer.anyIpv4(), Port.tcp(443), 'HTTPS');
     bbbSg.addIngressRule(Peer.anyIpv4(), Port.udpRange(16384, 32768), 'WebRTC');
@@ -40,26 +54,115 @@ export class BbbClusterStack extends Stack {
 
     const userData = UserData.forLinux();
     userData.addCommands(
+        'apt-get update -y && apt-get install -y jq awscli', // Ensure jq and awscli are installed
         'wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -v focal-270 -y',
         `scalelite-bbb-manager register ${props.scaleliteEndpoint.replace(
             'https://', ''
-        )} --secret ${props.sharedSecret.secretValue.toString()}`
+        )} --secret $(aws secretsmanager get-secret-value --secret-id ${props.sharedSecret.secretArn} --query SecretString --output text --region ${this.region} | jq -r .secret)`
     );
 
     const lt = new LaunchTemplate(this, 'BBBLaunchTemplate', {
       machineImage: ami,
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM),
+      instanceType: props.bbbInstanceType || InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM),
       securityGroup: bbbSg,
       keyName: props.keyName,
       userData
     });
 
-    new AutoScalingGroup(this, 'BBBASG', {
+    const asgProps = {
       vpc: props.vpc,
       launchTemplate: lt,
       minCapacity: 1,
       maxCapacity: 5,
       vpcSubnets: { subnetType: SubnetType.PUBLIC }
+    };
+
+    if (props.useSpotInstances) {
+      (asgProps as any).instanceMarketOptions = {
+        marketType: SpotMarketType.SPOT,
+        // Optionally, set spotOptions for maxPrice, interruption behavior etc.
+        // spotOptions: {
+        //   maxPrice: '0.10', // Example: Set max hourly price
+        //   spotInstanceType: SpotInstanceType.ONE_TIME,
+        //   instanceInterruptionBehavior: InstanceInterruptionBehavior.TERMINATE,
+        // },
+      };
+      // For better Spot resilience, consider using mixedInstancesPolicy
+      // to diversify across multiple instance types.
+    }
+
+    const asg = new AutoScalingGroup(this, 'BBBASG', asgProps);
+    props.sharedSecret.grantRead(asg.role); // Grant ASG role permission to read the secret
+
+    // --- Lifecycle Hook Setup ---
+
+    const lifecycleTopic = new sns.Topic(this, 'LifecycleSNSTopic');
+
+    const lambdaRole = new iam.Role(this, 'DeregisterLambdaRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole') // For VPC access
+      ],
+    });
+
+    lambdaRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['ec2:DescribeInstances', 'ec2:DescribeTags'], // To get instance details if needed
+      resources: ['*'], // Can be scoped down if specific tag-based lookups are used
+    }));
+    lambdaRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['autoscaling:CompleteLifecycleAction'],
+      resources: [`arn:aws:autoscaling:${this.region}:${this.account}:autoScalingGroup:*:autoScalingGroupName/${asg.autoScalingGroupName}`],
+    }));
+
+
+    const lambdaSg = new SecurityGroup(this, 'DeregisterLambdaSG', {
+        vpc: props.vpc,
+        description: 'Security Group for Deregistration Lambda',
+        allowAllOutbound: false // Be specific with outbound rules
+    });
+    // Allow outbound to Scalelite ALB (HTTPS typically) - Assuming Scalelite ALB SG is known or tagged
+    // For now, allowing to VPC CIDR as a placeholder. This should be refined.
+    // e.g., lambdaSg.addEgressRule(Peer.ipv4(props.vpc.vpcCidrBlock), Port.tcp(443), 'Allow outbound to Scalelite ALB');
+    // Allow outbound to Secrets Manager VPC Endpoint (HTTPS)
+    lambdaSg.addEgressRule(Peer.prefixList('pl-08b2fac53EXAMPLE'), Port.tcp(443), 'Allow outbound to Secrets Manager VPC Endpoint'); // Replace with actual prefix list for your region if possible, or use VPC CIDR for endpoint.
+
+    // The Python inline code and old lambda.Function definition are removed from here.
+
+    const deregisterLambda = new NodejsFunction(this, 'DeregisterLambdaHandler', {
+        runtime: lambda.Runtime.NODEJS_18_X,
+        entry: path.join(__dirname, '../../src/lambda-handlers/deregister-bbb-server.ts'),
+        handler: 'handler',
+        environment: {
+            SCALELITE_API_BASE_URL: `${props.scaleliteEndpoint}/scalelite/api`,
+            SHARED_SECRET_ARN: props.sharedSecret.secretArn,
+            AWS_REGION: this.region,
+        },
+        role: lambdaRole,
+        vpc: props.vpc,
+        vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },
+        securityGroups: [lambdaSg],
+        timeout: Duration.minutes(3),
+        bundling: {
+            externalModules: [
+                '@aws-sdk/client-secrets-manager',
+                '@aws-sdk/client-ec2',
+                '@aws-sdk/client-auto-scaling',
+                // 'axios' should be bundled by default if it's a dependency in package.json
+            ],
+            // Ensure esbuild is used if not default, or configure other options as needed
+        },
+    });
+    // Grant the new Lambda function permission to read the secret
+    props.sharedSecret.grantRead(deregisterLambda);
+
+    deregisterLambda.addEventSource(new lambdaEventSources.SnsEventSource(lifecycleTopic));
+
+    asg.addLifecycleHook('TerminateHook', {
+      lifecycleTransition: autoscaling.LifecycleTransition.INSTANCE_TERMINATING,
+      notificationTarget: new hookTargets.SnsTopic(lifecycleTopic),
+      defaultResult: autoscaling.DefaultResult.ABANDON, // Abandon if Lambda fails or times out
+      heartbeatTimeout: Duration.minutes(5),
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@aws-cdk/aws-ssm": "^1.204.0",
     "@aws-sdk/client-elasticache": "^3.812.0",
     "aws-cdk-lib": "^2.197.0",
+    "axios": "^1.7.2",
     "constructs": "^10.4.2"
   }
 }

--- a/src/lambda-handlers/deregister-bbb-server.ts
+++ b/src/lambda-handlers/deregister-bbb-server.ts
@@ -1,0 +1,237 @@
+import {
+    SecretsManagerClient,
+    GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
+import { EC2Client, DescribeInstancesCommand } from '@aws-sdk/client-ec2';
+import {
+    AutoScalingClient,
+    CompleteLifecycleActionCommand,
+} from '@aws-sdk/client-auto-scaling';
+import axios, { AxiosInstance } from 'axios';
+import { createHash } from 'node:crypto';
+import { URLSearchParams } from 'node:url'; // Used for consistent query param sorting
+
+// Interfaces
+interface SNSEventRecordMessage {
+    EC2InstanceId: string;
+    LifecycleHookName: string;
+    AutoScalingGroupName: string;
+    // Add other fields if necessary, like LifecycleActionToken, etc.
+}
+
+interface ScaleliteServer {
+    id: string;
+    server_id: string; // This is typically the hostname/identifier used by BBB
+    url: string;
+    secret: string; // Though we don't use this specific secret from getServers
+    // Add other fields if present in the getServers response
+}
+
+// Environment Variables
+const SCALELITE_API_BASE_URL = process.env.SCALELITE_API_BASE_URL!;
+const SHARED_SECRET_ARN = process.env.SHARED_SECRET_ARN!;
+const AWS_REGION = process.env.AWS_REGION!;
+
+if (!SCALELITE_API_BASE_URL || !SHARED_SECRET_ARN || !AWS_REGION) {
+    console.error('Missing critical environment variables: SCALELITE_API_BASE_URL, SHARED_SECRET_ARN, or AWS_REGION');
+    // In a real Lambda, this would cause an initialization error.
+    // For local testing, you'd want to throw or exit.
+    throw new Error('Missing critical environment variables.');
+}
+
+// AWS SDK Clients
+const smClient = new SecretsManagerClient({ region: AWS_REGION });
+const ec2Client = new EC2Client({ region: AWS_REGION });
+const asClient = new AutoScalingClient({ region: AWS_REGION });
+
+// Axios instance for HTTP requests
+const httpClient: AxiosInstance = axios.create({
+    timeout: 15000, // 15 seconds timeout
+});
+
+// Scalelite API Actions
+const GET_SERVERS_ACTION = 'getServers';
+const DELETE_SERVER_ACTION = 'deleteServer';
+
+function getSortedQueryString(queryParams: Record<string, string>): string {
+    if (Object.keys(queryParams).length === 0) {
+        return "";
+    }
+    // URLSearchParams sorts keys automatically upon construction if given an object
+    // or when iterating. For explicit alphabetical sort required by some APIs:
+    const params = new URLSearchParams();
+    Object.keys(queryParams).sort().forEach(key => {
+        params.append(key, queryParams[key]);
+    });
+    return params.toString();
+}
+
+function calculateChecksum(action: string, queryParamsString: string, requestBodyString: string, sharedSecret: string): string {
+    const stringToHash = action + queryParamsString + requestBodyString + sharedSecret;
+    console.debug(`String to hash for checksum (${action}): ${stringToHash}`);
+    return createHash('sha1').update(stringToHash).digest('hex');
+}
+
+
+export const handler = async (event: any): Promise<void> => {
+    console.info(`Received event: ${JSON.stringify(event)}`);
+
+    const snsMessageString = event.Records[0].Sns.Message;
+    const snsMessage: SNSEventRecordMessage = JSON.parse(snsMessageString);
+
+    const instanceId = snsMessage.EC2InstanceId;
+    const lifecycleHookName = snsMessage.LifecycleHookName;
+    const autoScalingGroupName = snsMessage.AutoScalingGroupName;
+
+    let lifecycleActionResult = 'ABANDON'; // Default to ABANDON
+
+    try {
+        if (!instanceId) {
+            console.error('EC2InstanceId not found in SNS message.');
+            throw new Error('EC2InstanceId missing from SNS message.');
+        }
+        if (!lifecycleHookName || !autoScalingGroupName) {
+            console.error('LifecycleHookName or AutoScalingGroupName not found in SNS message.');
+            throw new Error('Lifecycle details missing from SNS message.');
+        }
+
+        // 1. Get Shared Secret from Secrets Manager
+        console.info(`Fetching shared secret from ARN: ${SHARED_SECRET_ARN}`);
+        const secretValueCommand = new GetSecretValueCommand({ SecretId: SHARED_SECRET_ARN });
+        const secretValueOutput = await smClient.send(secretValueCommand);
+        if (!secretValueOutput.SecretString) {
+            console.error('SecretString not found in Secrets Manager response.');
+            throw new Error('Failed to retrieve valid secret from Secrets Manager.');
+        }
+        const sharedSecretData = JSON.parse(secretValueOutput.SecretString);
+        const sharedSecret = sharedSecretData.secret;
+        if (!sharedSecret) {
+            console.error("'secret' key not found in shared secret JSON from Secrets Manager.");
+            throw new Error('Invalid secret format from Secrets Manager.');
+        }
+        console.info('Successfully fetched shared secret.');
+
+        // 2. Get EC2 Instance PrivateDnsName
+        console.info(`Fetching instance details for EC2 instance: ${instanceId}`);
+        const describeInstancesCommand = new DescribeInstancesCommand({ InstanceIds: [instanceId] });
+        const ec2Output = await ec2Client.send(describeInstancesCommand);
+
+        const reservations = ec2Output.Reservations;
+        if (!reservations || reservations.length === 0 || !reservations[0].Instances || reservations[0].Instances.length === 0) {
+            console.error(`Could not find instance details for ${instanceId}`);
+            throw new Error(`Instance details not found for ${instanceId}.`);
+        }
+        const privateDnsName = reservations[0].Instances[0].PrivateDnsName;
+        if (!privateDnsName) {
+            console.error(`PrivateDnsName not found for ${instanceId}.`);
+            throw new Error(`PrivateDnsName not found for ${instanceId}.`);
+        }
+        // This is the URL format Scalelite usually stores for a BBB server registered via its hostname
+        // It's formed from the output of `bbb-conf --salt` (which is http://<hostname>/bigbluebutton/)
+        // and Scalelite typically polls `/api` on that, so the registered URL is often this:
+        const bbbServerApiUrl = `http://${privateDnsName}/bigbluebutton/api`;
+        console.info(`Constructed BBB server API URL for matching in Scalelite: ${bbbServerApiUrl}`);
+
+
+        // 3. Call Scalelite `getServers` API to find the internal Scalelite ID
+        console.info(`Calling Scalelite getServers API to find internal ID for server URL: ${bbbServerApiUrl}`);
+        const getServersQueryString = getSortedQueryString({}); // No specific query params for getServers other than checksum
+        const getServersChecksum = calculateChecksum(GET_SERVERS_ACTION, getServersQueryString, "", sharedSecret);
+        const getServersUrl = `${SCALELITE_API_BASE_URL}/${GET_SERVERS_ACTION}?${getServersQueryString ? getServersQueryString + '&' : ''}checksum=${getServersChecksum}`;
+        
+        console.info(`Calling getServers URL: ${getServersUrl}`);
+        const getServersResponse = await httpClient.get<{ status: string, servers?: ScaleliteServer[] }>(getServersUrl);
+        console.info(`getServers response status: ${getServersResponse.status}, data: ${JSON.stringify(getServersResponse.data)}`);
+
+        if (getServersResponse.status !== 200 || getServersResponse.data.status !== 'ok' || !getServersResponse.data.servers) {
+            console.error(`getServers API call failed or returned unexpected data. Status: ${getServersResponse.status}, Body: ${JSON.stringify(getServersResponse.data)}`);
+            throw new Error('Failed to fetch servers from Scalelite or unexpected response format.');
+        }
+
+        let scaleliteInternalServerId: string | null = null;
+        for (const server of getServersResponse.data.servers) {
+            if (server.url === bbbServerApiUrl) {
+                scaleliteInternalServerId = server.id;
+                console.info(`Found Scalelite internal server ID: ${scaleliteInternalServerId} for URL ${bbbServerApiUrl}`);
+                break;
+            }
+        }
+
+        if (!scaleliteInternalServerId) {
+            console.warn(`Could not find server with URL ${bbbServerApiUrl} in Scalelite's getServers response. Assuming already deregistered or registration failed.`);
+            lifecycleActionResult = 'CONTINUE'; // Allow ASG to proceed
+        } else {
+            // 4. Call Scalelite `deleteServer` API
+            console.info(`Preparing to call deleteServer for Scalelite internal ID: ${scaleliteInternalServerId}`);
+            const deletePayload = { id: scaleliteInternalServerId };
+            const deleteBodyString = JSON.stringify(deletePayload);
+            const deleteServerQueryString = getSortedQueryString({}); // No specific query params for deleteServer other than checksum
+            
+            const deleteChecksum = calculateChecksum(DELETE_SERVER_ACTION, deleteServerQueryString, deleteBodyString, sharedSecret);
+            const deleteUrl = `${SCALELITE_API_BASE_URL}/${DELETE_SERVER_ACTION}?${deleteServerQueryString ? deleteServerQueryString + '&' : ''}checksum=${deleteChecksum}`;
+            
+            console.info(`Calling Scalelite deleteServer API URL: ${deleteUrl} with body: ${deleteBodyString}`);
+            const deleteServerResponse = await httpClient.post(deleteUrl, deletePayload, {
+                headers: { 'Content-Type': 'application/json' }
+            });
+            console.info(`deleteServer response status: ${deleteServerResponse.status}, data: ${JSON.stringify(deleteServerResponse.data)}`);
+
+            // Scalelite's JSON API for deleteServer typically returns { "status": "ok", "message": "ok" } on success
+            if (deleteServerResponse.status === 200 && deleteServerResponse.data.status === 'ok') {
+                console.info(`Successfully deregistered Scalelite internal ID ${scaleliteInternalServerId} from Scalelite.`);
+                lifecycleActionResult = 'CONTINUE';
+            } else if (deleteServerResponse.status === 200 && typeof deleteServerResponse.data === 'string' && deleteServerResponse.data.includes('<returncode>SUCCESS</returncode>')) {
+                // Fallback for older XML-like responses if Content-Type was not strictly application/json by Scalelite
+                console.info(`Successfully deregistered Scalelite internal ID ${scaleliteInternalServerId} from Scalelite (XML success).`);
+                lifecycleActionResult = 'CONTINUE';
+            }
+            else {
+                console.error(`Scalelite deleteServer API did not report success for ID ${scaleliteInternalServerId}. Status: ${deleteServerResponse.status}, Response: ${JSON.stringify(deleteServerResponse.data)}`);
+                // Keep lifecycleActionResult as 'ABANDON'
+            }
+        }
+
+    } catch (error: any) {
+        console.error(`An error occurred during the deregistration process: ${error.message}`, error.stack);
+        // lifecycleActionResult remains 'ABANDON'
+    } finally {
+        console.info(`Completing lifecycle action with result: ${lifecycleActionResult}`);
+        const completeLifecycleParams = {
+            LifecycleHookName: lifecycleHookName,
+            AutoScalingGroupName: autoScalingGroupName,
+            LifecycleActionResult: lifecycleActionResult,
+            InstanceId: instanceId,
+        };
+        try {
+            const completeLifecycleCommand = new CompleteLifecycleActionCommand(completeLifecycleParams);
+            await asClient.send(completeLifecycleCommand);
+            console.info(`Successfully completed lifecycle action for instance ${instanceId} with result ${lifecycleActionResult}.`);
+        } catch (completionError: any) {
+            console.error(`Failed to complete lifecycle action for instance ${instanceId}: ${completionError.message}`, completionError.stack);
+            // This is a critical failure; the instance might remain in Terminating:Wait or be terminated by ASG timeout
+        }
+    }
+    console.info(`Lambda execution finished. Action result: ${lifecycleActionResult}`);
+};
+
+// For local testing (optional)
+// (async () => {
+//     if (process.env.LOCAL_TEST) {
+//         const testEvent = {
+//             Records: [{
+//                 Sns: {
+//                     Message: JSON.stringify({
+//                         EC2InstanceId: "i-xxxxxxxxxxxxxxxxx", // Replace with a test instance ID
+//                         LifecycleHookName: "TestHook",
+//                         AutoScalingGroupName: "TestASG"
+//                     })
+//                 }
+//             }]
+//         };
+//         // Mock environment variables for local testing
+//         process.env.SCALELITE_API_BASE_URL = "YOUR_SCALELITE_API_URL"; // e.g. https://scalelite.example.com/scalelite/api
+//         process.env.SHARED_SECRET_ARN = "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:your-secret-name-XXXXXX";
+//         process.env.AWS_REGION = "your-region";
+//         await handler(testEvent);
+//     }
+// })();

--- a/test/bbb-cdk.test.ts
+++ b/test/bbb-cdk.test.ts
@@ -1,17 +1,108 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as BbbCdk from '../lib/bbb-cdk-stack';
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Vpc, InstanceType, InstanceClass, InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { BbbClusterStack } from '../lib/bbb-cluster-stack'; // Adjust path if necessary
 
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/bbb-cluster-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new BbbCdk.BbbClusterStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
+test('BBB Cluster Stack Synthesizes with On-Demand Instances', () => {
+  const app = new cdk.App();
+  const parentStack = new cdk.Stack(app, "ParentTestStackOD", {
+    env: { account: '123456789012', region: 'us-east-1' } // Specify env for region-dependent lookups like SSM
+  });
 
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
+  // Create a dummy VPC for the test
+  const vpc = new Vpc(parentStack, 'TestVPCOD');
+
+  // Create a dummy Secret for the test
+  const sharedSecret = new Secret(parentStack, 'TestSharedSecretOD', {
+    secretObjectValue: {
+      secret: cdk.SecretValue.unsafePlainText('dummy-secret-value')
+    }
+  });
+
+  // Instantiate the BbbClusterStack for On-Demand
+  const bbbClusterStack = new BbbClusterStack(app, 'MyTestBbbClusterStackOD', {
+    vpc: vpc,
+    scaleliteEndpoint: 'https://scalelite.example.com/bigbluebutton/api',
+    sharedSecret: sharedSecret,
+    keyName: 'test-key',
+    bbbInstanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+    useSpotInstances: false,
+    sshAllowedCidr: '10.0.0.0/24',
+    env: { account: '123456789012', region: 'us-east-1' }
+  });
+
+  // Prepare the stack for assertions.
+  const template = Template.fromStack(bbbClusterStack);
+
+  // Assertion: Check if an AutoScalingGroup resource is created
+  template.resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 1);
+
+  // Assertion: Check if a LaunchTemplate is created
+  template.resourceCountIs('AWS::EC2::LaunchTemplate', 1);
+
+  // Assertion: Check if required SecurityGroups are created (BBB SG, Lambda SG)
+  template.resourceCountIs('AWS::EC2::SecurityGroup', 2); 
+  
+  // Check for Lifecycle Hook
+  template.resourceCountIs('AWS::AutoScaling::LifecycleHook', 1);
+
+  // Check for Lambda Function (for deregistration)
+  template.resourceCountIs('AWS::Lambda::Function', 1);
+  
+  // Check for SNS Topic
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+
+  // Check that ASG does NOT have InstanceMarketOptions for On-Demand
+  template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    LaunchTemplateSpecification: Match.anyValue(), // Basic check
+    InstanceMarketOptions: Match.absent() // Should not be present for on-demand
+  });
+});
+
+
+test('BBB Cluster Stack Synthesizes with Spot Instances', () => {
+  const app = new cdk.App();
+  const parentStack = new cdk.Stack(app, "ParentTestStackSpot", {
+    env: { account: '123456789012', region: 'us-east-1' } // Specify env
+  });
+  const vpc = new Vpc(parentStack, 'TestVPCSpot');
+  const sharedSecret = new Secret(parentStack, 'TestSharedSecretSpot', {
+    secretObjectValue: {
+      secret: cdk.SecretValue.unsafePlainText('dummy-secret-value')
+    }
+  });
+
+  // Instantiate the BbbClusterStack for Spot Instances
+  const spotBbbClusterStack = new BbbClusterStack(app, 'MySpotTestBbbClusterStack', {
+    vpc: vpc,
+    scaleliteEndpoint: 'https://scalelite.example.com/bigbluebutton/api',
+    sharedSecret: sharedSecret,
+    keyName: 'test-key-spot',
+    bbbInstanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+    useSpotInstances: true, // Enable spot instances
+    sshAllowedCidr: '10.0.0.1/32',
+    env: { account: '123456789012', region: 'us-east-1' }
+  });
+
+  const spotTemplate = Template.fromStack(spotBbbClusterStack);
+
+  // Check if an AutoScalingGroup resource is created
+  spotTemplate.resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 1);
+
+  // Check if the ASG has InstanceMarketOptions property when useSpotInstances is true
+  spotTemplate.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    LaunchTemplateSpecification: Match.anyValue(), // Basic check
+    InstanceMarketOptions: {
+      MarketType: 'spot',
+      // SpotOptions: Match.anyValue() // SpotOptions can be checked if specific values are set
+    }
+  });
+
+  // Verify other relevant resources are also created in Spot scenario
+  spotTemplate.resourceCountIs('AWS::EC2::LaunchTemplate', 1);
+  spotTemplate.resourceCountIs('AWS::EC2::SecurityGroup', 2); // BBB SG, Lambda SG
+  spotTemplate.resourceCountIs('AWS::AutoScaling::LifecycleHook', 1);
+  spotTemplate.resourceCountIs('AWS::Lambda::Function', 1);
+  spotTemplate.resourceCountIs('AWS::SNS::Topic', 1);
 });


### PR DESCRIPTION
Removes the previously commented-out inline Python code for the de-registration Lambda function from `lib/bbb-cluster-stack.ts`. This code was replaced by the new TypeScript-based `NodejsFunction` in the preceding commit.

This change cleans up the `BbbClusterStack` file.